### PR TITLE
Bump community 1.0 version to stable-20201119.1

### DIFF
--- a/resources/community-1.0/kustomization.yaml
+++ b/resources/community-1.0/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
 - name: morphicworld/morphiccommunity
   newName: morphicworld/morphiccommunity
-  newTag: stable-20200930.32
+  newTag: stable-20201119.1


### PR DESCRIPTION
Manual update of the version until https://morphic.atlassian.net/jira/software/c/projects/MOR/issues/MOR-369 is fixed.